### PR TITLE
fix(auth)!: return old auth system

### DIFF
--- a/backend/api/v1/urls.py
+++ b/backend/api/v1/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     path('metrics/', include(urls_metrics)),
     path('', include(urls_events)),
     path('services/', include(urls_services)),
+    path('auth/', include('djoser.urls.jwt')),
     re_path(
         r'^swagger(?P<format>\.json|\.yaml)$',
         schema_view.without_ui(cache_timeout=0),

--- a/backend/api/v1/users/serializers.py
+++ b/backend/api/v1/users/serializers.py
@@ -2,9 +2,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.password_validation import validate_password
 from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
-from rest_framework_simplejwt.exceptions import InvalidToken
-from rest_framework_simplejwt.serializers import (TokenObtainPairSerializer,
-                                                  TokenRefreshSerializer)
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
 from sorl.thumbnail import get_thumbnail
 
 from api.v1.metrics.serializers import ConditionReadSerializer
@@ -271,15 +269,3 @@ class CustomTokenObtainSerializer(TokenObtainPairSerializer):
     def validate(self, attrs):
         attrs["email"] = attrs.get("email").lower()
         return super(CustomTokenObtainSerializer, self).validate(attrs)
-
-
-class CookieTokenRefreshSerializer(TokenRefreshSerializer):
-    refresh = None
-
-    def validate(self, attrs):
-        attrs['refresh'] = self.context['request'].COOKIES.get('refresh_token')
-        if attrs['refresh']:
-            return super().validate(attrs)
-        raise InvalidToken(
-            'Refresh токен недействителен, либо не обнаружен в cookies'
-        )

--- a/backend/api/v1/users/urls.py
+++ b/backend/api/v1/users/urls.py
@@ -46,25 +46,5 @@ urlpatterns = [
         views.PasswordChangeView.as_view(),
         name='password_change'
     ),
-    re_path(
-        r'^auth/jwt/create/?$',
-        views.CookieTokenObtainPairView.as_view(),
-        name='token_obtain_pair'
-    ),
-    re_path(
-        r'^auth/jwt/refresh/?$',
-        views.CookieTokenRefreshView.as_view(),
-        name='token_refresh'
-    ),
-    re_path(
-        r'^auth/jwt/cookie/?$',
-        views.CookieTokenDeleteView.as_view(),
-        name='token_delete'
-    ),
-    re_path(
-        r'^auth/jwt/verify/?$',
-        views.CookieTokenVerifyView.as_view(),
-        name='token_verify'
-    ),
     path('', include(v10.urls)),
 ]

--- a/backend/api/v1/users/views.py
+++ b/backend/api/v1/users/views.py
@@ -3,7 +3,6 @@ import uuid
 from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.hashers import make_password
-from django.http import HttpResponse
 from django_filters.rest_framework import DjangoFilterBackend
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
@@ -13,8 +12,6 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
-from rest_framework_simplejwt.views import (TokenObtainPairView,
-                                            TokenRefreshView, TokenVerifyView)
 
 from api.v1.permissions import (AllReadOnlyPermissions, ChiefSafePermission,
                                 HRAllPermission)
@@ -25,8 +22,8 @@ from users.models import (Department, Hobby, InviteCode, PasswordResetCode,
 
 from .filters import (DepartmentInviteCodeFilter, ElasticSearchFilter,
                       PositionInviteCodeFilter)
-from .serializers import (CookieTokenRefreshSerializer, DepartmentSerializer,
-                          HobbySerializer, PasswordChangeSerializer,
+from .serializers import (DepartmentSerializer, HobbySerializer,
+                          PasswordChangeSerializer,
                           PasswordResetConfirmSerializer,
                           PasswordResetSerializer, PositionSerializer,
                           RegisterSerializer, SendInviteSerializer,
@@ -394,83 +391,3 @@ class HobbyViewSet(ModelViewSet):
         if self.request.method == 'GET':
             self.permission_classes = (AllowAny,)
         return super().get_permissions()
-
-
-class CookieTokenObtainPairView(TokenObtainPairView):
-
-    @swagger_auto_schema(
-        responses={
-            201: openapi.Response(
-                schema=CookieTokenRefreshSerializer,
-                description=(
-                    'Вместе с access токеном в ответе, '
-                    'в cookies передается refresh токен'
-                )
-            ),
-            401: openapi.Response(
-                'Не найдено активной учетной записи с указанными данными'
-            ),
-        }
-    )
-    def post(self, request, *args, **kwargs):
-        return super().post(request, *args, **kwargs)
-
-    def finalize_response(self, request, response, *args, **kwargs):
-        if response.data.get('refresh'):
-            cookie_max_age = 3600 * 24 * settings.REFRESH_TOKEN_LIFETIME_DAYS
-            response.set_cookie(
-                'refresh_token',
-                response.data['refresh'],
-                max_age=cookie_max_age,
-                httponly=True
-            )
-            del response.data['refresh']
-        return super().finalize_response(request, response, *args, **kwargs)
-
-
-class CookieTokenRefreshView(TokenRefreshView):
-    serializer_class = CookieTokenRefreshSerializer
-
-    @swagger_auto_schema(
-        responses={
-            401: openapi.Response(
-                'Refresh токен недействителен, либо не обнаружен в cookies'
-            ),
-        }
-    )
-    def post(self, request, *args, **kwargs):
-        return super().post(request, *args, **kwargs)
-
-
-class CookieTokenVerifyView(TokenVerifyView):
-    serializer_class = CookieTokenRefreshSerializer
-
-    @swagger_auto_schema(
-        responses={
-            200: openapi.Response('Токен успешно подтвержден'),
-            401: openapi.Response(
-                'Refresh токен недействителен, либо не обнаружен в cookies'
-            ),
-        },
-    )
-    def post(self, request, *args, **kwargs):
-        return super().post(request, *args, **kwargs)
-
-    def finalize_response(self, request, response, *args, **kwargs):
-        if response.data.get('access'):
-            del response.data['access']
-        return super().finalize_response(request, response, *args, **kwargs)
-
-
-class CookieTokenDeleteView(APIView):
-    permission_classes = (AllowAny,)
-
-    @swagger_auto_schema(
-        responses={
-            204: openapi.Response('Refresh токен успешно удален из cookies')
-        },
-    )
-    def delete(self, request):
-        response = HttpResponse(status=status.HTTP_204_NO_CONTENT)
-        response.delete_cookie('refresh_token')
-        return response


### PR DESCRIPTION
Вернул старую систему аутентификации без кук. Т.к в условиях когда у фронтов локально развернут их проект и подключаются они к api на dev сервере, куки никак не сохраняются. Уже и с cors время потратил и проксированием, из рабочих вариантов там есть лютый костыль локальный с hosts, но это еще кучу времени и надо всем участникам команды ставить, что совсем не ок для разработки. Разворачивать же всем фронтам локально у себя бэк и постоянно его обновлять лишь только для того чтобы куки работали, это то же явно не выход.